### PR TITLE
[Update] change font-family to Kosugi maru [ci skip]

### DIFF
--- a/app/javascript/src/custom.scss
+++ b/app/javascript/src/custom.scss
@@ -1,6 +1,7 @@
 $main-color: #eb616c;
 
 body {
+    font-family: 'Kosugi Maru', sans-serif;
     background-color:#faf3ea;
     padding-top:90px;
     #wrapper {
@@ -27,7 +28,6 @@ body {
 }
 
 .container {
-    font-family:Meiryo;
     border-radius:4px;
     h2 {
         width:100%;
@@ -35,7 +35,6 @@ body {
     }
     h1 {
         font-size:20px;
-        font-family:Meiryo;
         color:grey;
     }
 }
@@ -48,7 +47,6 @@ body {
     box-shadow:1px 1px 1px #ccc;
     font-weight:700;
     .navbar-brand {
-        font-family:Meiryo;
         font-weight:900;
         font-size:xx-large;
     }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <link href="https://fonts.googleapis.com/earlyaccess/nicomoji.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet">
     <%= analytics_init if Rails.env.production? %>
   </head>
 


### PR DESCRIPTION
iphoneで確認した時にメイリオが反映されてなかった。
なので全てのデバイスでフォントを統一するためにwebフォントへ変更。
フォントの種類はKosugi maruを使用。
close #117 