### PR TITLE
[Update] fix #comment_area overflow [ci skip]

### DIFF
--- a/app/javascript/src/custom.scss
+++ b/app/javascript/src/custom.scss
@@ -268,6 +268,7 @@ body {
         #comment_area {
             flex-grow:4;
             flex-basis:60%;
+            word-break: break-all;
         }
     }
 }


### PR DESCRIPTION
コメントがある程度の文字量を超えるとはみ出る現象が発生。
CSSにて無条件に端に達したら折り返すように改修。
close #134 