### PR TITLE
[Update] rspec type:requests comments [ci skip]

### DIFF
--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Comment', type: :request do
                 params = {
                     comment: {
                         post_id: 1,
-                        comment: "a"*255
+                        comment: "a"*1000
                     }
                 }
                 expect do
@@ -19,12 +19,12 @@ RSpec.describe 'Comment', type: :request do
                 expect(response).to have_http_status 302
                 expect(response).to redirect_to post_path(post1)
             end
-            it '１０００文字以上だとリクエスト不成功' do
+            it '１００１文字以上だとリクエスト不成功' do
                 sign_in(post1.user)
                 params = {
                     comment: {
                         post_id: 1,
-                        comment: "a"*256
+                        comment: "a"*1001
                     }
                 }
                 expect do


### PR DESCRIPTION
コメントテーブルのcommentカラムの型を修正したことで
下記リクエストスペックも修正。
－１０００文字以内だとリクエスト成功
－１００１文字以上だとリクエスト不成功
close #151 
