### PR TITLE
[Update] mail_authentication spec

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     email { "test@test.com" }
     password { "password3" }
     password_confirmation { "password3" }
+    confirmed_at { Time.now }
     
     trait :other do
       id { 2 }

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Users', type: :request do
           }
         }
         post user_registration_path, params: params
-        expect(response).to redirect_to user_path(3)
+        expect(response).to redirect_to root_path
       end
     end
   end

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -30,9 +30,9 @@ RSpec.feature 'Registration', type: :system do
         #新規登録ボタンをクリック
         click_button '新規登録'
         
-        #マイページへリダイレクト
-        expect(page).to have_content 'マイページ'
-        expect(page).to have_content 'アカウント登録が完了しました。'
+        #トップページへリダイレクト
+        expect(page).to have_content '人に言えない悩みや愚痴がある子育て中のママへ'
+        expect(page).to have_content '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
     end
     
     scenario 'ユーザーネームがブランクの場合' do


### PR DESCRIPTION
メール認証機能の追加に伴い
specでエラーが大量発生！

下記改修でエラーを解消。
－feature_botのユーザーデータにてconfirmed_atを追加
－新規登録ボタンをクリック後の挙動