### PR TITLE
[Update] main-image heading

### DIFF
--- a/app/views/layouts/_not_signed_index.html.erb
+++ b/app/views/layouts/_not_signed_index.html.erb
@@ -2,7 +2,7 @@
     <%= render 'layouts/flashes' %>
     <div id="main_image">
         <%= image_pack_tag 'main_image.jpg', class: "img-fluid d-block mx-auto" %>
-        <h1>人に言えない悩みや愚痴がある子育て中のママへ</h1>
+        <h1>育児の孤独感やママ友の悩みを抱え込まず共有しましょう</h1>
     </div>
     <%= link_to '投稿する',new_user_registration_path, class:'btn btn-danger btn-lg my-4' %>
     <h2 class="my-3 mx-auto">新着投稿一覧</h2>

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'home', type: :system do
         
         #トップページの各項目を確認
         expect(page).to have_selector 'img'
-        expect(page).to have_selector 'h1', text: '人に言えない悩みや愚痴がある子育て中のママへ'
+        expect(page).to have_selector 'h1', text: '育児の孤独感やママ友の悩みを抱え込まず共有しましょう'
         expect(page).to have_link '投稿する'
         expect(page).to have_selector 'h2', text: '新着投稿一覧'
         expect(page).to have_selector 'p', text: '投稿一覧を全て見たい方はログインしてください。'

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Registration', type: :system do
         click_button '新規登録'
         
         #トップページへリダイレクト
-        expect(page).to have_content '人に言えない悩みや愚痴がある子育て中のママへ'
+        expect(page).to have_content '育児の孤独感やママ友の悩みを抱え込まず共有しましょう'
         expect(page).to have_content '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
     end
     


### PR DESCRIPTION
検索結果にて表示された対策ワードを盛り込み、サイト内容を簡単に説明した文言へ変更
close #182